### PR TITLE
Beto/updating gemfile

### DIFF
--- a/ruby/build.sh
+++ b/ruby/build.sh
@@ -18,4 +18,4 @@ else
 fi
 
 # Build gem
-cd gem && gem build trinsic_service_clients.gemspec cd ..
+cd gem && gem build trinsic_service_clients.gemspec && cd ..

--- a/ruby/gem/Gemfile
+++ b/ruby/gem/Gemfile
@@ -1,3 +1,13 @@
 source "https://rubygems.org"
 
+gem "timeliness", "~> 0.3.10"
+
+gem "faraday", "~> 1.4"
+
+gem "faraday-cookie_jar", "~> 0.0.7"
+
+gem 'concurrent-ruby', '~> 1.0', '>= 1.0.5'
+
+gem 'ms_rest', '~> 0.7.4'
+
 gemspec

--- a/ruby/gem/trinsic_service_clients.gemspec
+++ b/ruby/gem/trinsic_service_clients.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name          = 'trinsic_service_clients'
-  s.version       = '0.0.0'
+  s.version       = '1.1.4000'
   s.date          = '2020-08-20'
   s.summary       = "Trinsic Service Clients"
   s.description   = "A gem to access Trinsic's APIs"


### PR DESCRIPTION
Changes:
* Added dependencies to Gemfile so a "bundle install" is all that is required.
* Changed script because I was getting an error where "cd .." was being taken as a parameter
* I added the changes to the .gemspec file since this is technically a new version

I made these changes so that our users could use the ruby sdk with the required dependencies. 
I tested my changes by making sure that if I tried to use a test.rb file that required the trinsic service client that it would build correctly after requiring a bundle install of the dependencies. @tmarkovski Let me know what you think and I can make any changes if needed.